### PR TITLE
fix: audio graph rebuild connections

### DIFF
--- a/src/contexts/audio-player-context.tsx
+++ b/src/contexts/audio-player-context.tsx
@@ -152,6 +152,16 @@ export const AudioPlayerProvider = ({ children }: AudioPlayerProviderProps) => {
     }
 
     const ctx = ctxRef.current
+
+    // Disconnect existing connections to avoid creating duplicate audio paths
+    gainRef.current.disconnect()
+    panRef.current.disconnect()
+    eqRef.current[400].disconnect()
+    eqRef.current[1000].disconnect()
+    eqRef.current[2500].disconnect()
+    eqRef.current[6300].disconnect()
+    eqRef.current[16000].disconnect()
+
     sourceRef.current
       .connect(gainRef.current)
       .connect(panRef.current)


### PR DESCRIPTION
## Summary
- prevent duplicate connections by disconnecting existing nodes when building the audio graph

## Testing
- `npm run check` *(fails: biome not installed)*
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fd22815f8832abc7742f8093402bb