### PR TITLE
Fix Vite base for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: jdx/mise-action@v2
       - run: bun install --frozen-lockfile
-      - run: bun run build
+      - run: bun run build -- --base=/music-player/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist


### PR DESCRIPTION
## Summary
- ensure built site uses `/music-player/` base path

## Testing
- `bun run check:write && bun run typecheck && bun run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_683fdc242810832ab8e561139b8722ae